### PR TITLE
Fix wrong TypeScript export definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,7 @@ declare module 'fastify' {
   }
 }
 
-declare const fastifyRequestContext: FastifyPlugin<RequestContextOptions>
+declare const fastifyRequestContextPlugin: FastifyPlugin<RequestContextOptions>
 declare const requestContext: RequestContext
 
-export { fastifyRequestContext, requestContext }
+export { fastifyRequestContextPlugin, requestContext }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,4 @@
-import { requestContext, fastifyRequestContext, RequestContextOptions, RequestContext } from './index'
+import { requestContext, fastifyRequestContextPlugin, RequestContextOptions, RequestContext } from './index'
 import { expectAssignable, expectType } from 'tsd'
 import { FastifyInstance, RouteHandlerMethod } from 'fastify'
 
@@ -7,7 +7,7 @@ const middie = require('middie')
 
 const app: FastifyInstance = fastify()
 app.register(middie)
-app.register(fastifyRequestContext)
+app.register(fastifyRequestContextPlugin)
 
 expectAssignable<RequestContextOptions>({})
 expectAssignable<RequestContextOptions>({


### PR DESCRIPTION
The TypeScript definition included exports the plugin as `fastifyRequestContext`, which should have been `fastifyRequestContextPlugin`. This PR fixes it and makes the library usable for TypeScript users.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
