### PR TITLE
Enable specifying interface for context data

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,23 @@ app.listen(3000, (err, address) => {
 return app.ready()
 ```
 
+In TypeScript you can augment the module to type your conext:
+
+```ts
+import {requestContext} from 'fastify-request-context'
+
+declare module 'fastify-request-context' {
+  interface RequestContextData {
+    foo: string
+  }
+}
+
+// Type is string
+const foo = requestContext.get('foo')
+// Type for unspecified keys is any
+const bar = requestContext.get('bar')``ts
+```
+
 [npm-image]: https://img.shields.io/npm/v/fastify-request-context.svg
 [npm-url]: https://npmjs.org/package/fastify-request-context
 [downloads-image]: https://img.shields.io/npm/dm/fastify-request-context.svg

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ app.listen(3000, (err, address) => {
 return app.ready()
 ```
 
-In TypeScript you can augment the module to type your conext:
+In TypeScript you can augment the module to type your context:
 
 ```ts
 import {requestContext} from 'fastify-request-context'
@@ -101,7 +101,7 @@ declare module 'fastify-request-context' {
 // Type is string
 const foo = requestContext.get('foo')
 // Type for unspecified keys is any
-const bar = requestContext.get('bar')``ts
+const bar = requestContext.get('bar')
 ```
 
 [npm-image]: https://img.shields.io/npm/v/fastify-request-context.svg

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,12 @@
-import { FastifyPlugin, FastifyRequest } from 'fastify'
+import { FastifyPlugin } from 'fastify'
 
-export type RequestContext = {
-  get: <T>(key: string) => T | undefined
-  set: <T>(key: string, value: T) => void
+export interface RequestContextData {
+  [key: string]: any
+}
+
+export interface RequestContext {
+  get<K extends keyof RequestContextData>(key: K): RequestContextData[K] | undefined
+  set<K extends keyof RequestContextData>(key: K, value: RequestContextData[K]): void
 }
 
 export type Hook =
@@ -20,8 +24,8 @@ export type Hook =
   | 'onReady'
   | 'onClose'
 
-export type RequestContextOptions = {
-  defaultStoreValues?: Record<string, any>
+export interface RequestContextOptions {
+  defaultStoreValues?: RequestContextData
   hook?: Hook
 }
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,9 @@
-import { requestContext, fastifyRequestContextPlugin, RequestContextOptions, RequestContext } from './index'
+import {
+  requestContext,
+  fastifyRequestContextPlugin,
+  RequestContextOptions,
+  RequestContext,
+} from './index'
 import { expectAssignable, expectType } from 'tsd'
 import { FastifyInstance, RouteHandlerMethod } from 'fastify'
 
@@ -24,3 +29,12 @@ expectType<RequestContext>(requestContext)
 const getHandler: RouteHandlerMethod = function (request, _reply) {
   expectType<RequestContext>(request.requestContext)
 }
+
+declare module './index' {
+  interface RequestContextData {
+    foo?: string
+  }
+}
+
+expectType<string | undefined>(requestContext.get('foo'))
+expectType<any>(requestContext.get('bar'))

--- a/test/requestContextPlugin.spec.js
+++ b/test/requestContextPlugin.spec.js
@@ -21,7 +21,7 @@ describe('requestContextPlugin', () => {
         const promiseRequest1 = new Promise((resolveRequest1Promise) => {
           const route = (req, reply) => {
             function prepareReply() {
-              testService.processRequest(requestId).then(() => {
+              return testService.processRequest(requestId).then(() => {
                 const storedValue = req.requestContext.get('testKey')
                 reply.status(204).send({
                   storedValue,
@@ -96,7 +96,7 @@ describe('requestContextPlugin', () => {
         const promiseRequest1 = new Promise((resolveRequest1Promise) => {
           const route = (req, reply) => {
             function prepareReply() {
-              testService.processRequest(requestId).then(() => {
+              return testService.processRequest(requestId).then(() => {
                 const storedValue = req.requestContext.get('testKey')
                 reply.status(204).send({
                   storedValue,
@@ -173,7 +173,7 @@ describe('requestContextPlugin', () => {
             const requestId = req.requestContext.get('testKey')
 
             function prepareReply() {
-              testService.processRequest(requestId.replace('testValue', '')).then(() => {
+              return testService.processRequest(requestId.replace('testValue', '')).then(() => {
                 const storedValue = req.requestContext.get('testKey')
                 reply.status(204).send({
                   storedValue,


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This allows specifying types for the data stored in the request context which are then respected by `get` and `set`.

`npm run test:typescript` still passes.

```TypeScript
import {requestContext} from 'fastify-request-context'

declare module 'fastify-request-context' {
  interface RequestContextData {
    foo: string
  }
}

// Type is string
const foo = requestContext.get('foo')
// Type for unspecified keys is any as before
const bar = requestContext.get('bar')
```