### PR TITLE
revert: add back `preParsing` hook related code

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,7 @@ export interface RequestContext {
 
 export type Hook =
   | 'onRequest'
+  | 'preParsing'
   | 'preValidation'
   | 'preHandler'
   | 'preSerialization'

--- a/lib/requestContextPlugin.js
+++ b/lib/requestContextPlugin.js
@@ -24,11 +24,11 @@ function plugin(fastify, opts, next) {
     }, opts.defaultStoreValues)
   })
 
-  // onRequest is executed after the als.runWith call within the "proper" async context (AsyncResource implicitly created by ALS).
+  // Both of onRequest and preParsing are executed after the als.runWith call within the "proper" async context (AsyncResource implicitly created by ALS).
   // However, preValidation, preHandler and the route handler are executed as a part of req.emit('end') call which happens
   // in a different async context, as req/res may emit events in a different context.
   // Related to https://github.com/nodejs/node/issues/34430 and https://github.com/nodejs/node/issues/33723
-  if (hook === 'onRequest') {
+  if (hook === 'onRequest' || hook === 'preParsing') {
     fastify.addHook('preValidation', (req, res, done) => {
       const asyncResource = req[asyncResourceSymbol]
       asyncResource.runInAsyncScope(done, req.raw)

--- a/test-tap/requestContextPlugin.e2e.test.js
+++ b/test-tap/requestContextPlugin.e2e.test.js
@@ -83,7 +83,7 @@ test('correctly preserves values set in prevalidation phase within single POST r
 })
 
 test('correctly preserves values set in multiple phases within single POST request', (t) => {
-  t.plan(8)
+  t.plan(10)
 
   let testService
   let responseCounter = 0
@@ -92,10 +92,12 @@ test('correctly preserves values set in multiple phases within single POST reque
       const promiseRequest1 = new Promise((resolveRequest1Promise) => {
         const route = (req) => {
           const onRequestValue = req.requestContext.get('onRequest')
+          const preParsingValue = req.requestContext.get('preParsing')
           const preValidationValue = req.requestContext.get('preValidation')
           const preHandlerValue = req.requestContext.get('preHandler')
 
           t.equal(onRequestValue, undefined)
+          t.equal(preParsingValue, undefined)
           t.type(preValidationValue, 'number')
           t.type(preHandlerValue, 'number')
 
@@ -160,14 +162,16 @@ test('correctly preserves values set in multiple phases within single POST reque
 })
 
 test('correctly preserves values set in multiple phases within single POST request', (t) => {
-  t.plan(6)
+  t.plan(7)
 
   const route = (req) => {
     const onRequestValue = req.requestContext.get('onRequest')
+    const preParsingValue = req.requestContext.get('preParsing')
     const preValidationValue = req.requestContext.get('preValidation')
     const preHandlerValue = req.requestContext.get('preHandler')
 
     t.equal(onRequestValue, 'dummy')
+    t.equal(preParsingValue, 'dummy')
     t.type(preValidationValue, 'number')
     t.type(preHandlerValue, 'number')
 

--- a/test/internal/appInitializer.js
+++ b/test/internal/appInitializer.js
@@ -47,6 +47,11 @@ function initAppPostWithAllPlugins(endpoint, requestHook) {
     done()
   })
 
+  app.addHook('preParsing', (req, reply, payload, done) => {
+    req.requestContext.set('preParsing', 'dummy')
+    done(null, payload)
+  })
+
   app.addHook('preValidation', (req, reply, done) => {
     const requestId = Number.parseInt(req.body.requestId)
     req.requestContext.set('preValidation', requestId)

--- a/test/requestContextPlugin.e2e.spec.js
+++ b/test/requestContextPlugin.e2e.spec.js
@@ -82,7 +82,7 @@ describe('requestContextPlugin E2E', () => {
   })
 
   it('correctly preserves values set in multiple phases within single POST request', () => {
-    expect.assertions(8)
+    expect.assertions(10)
 
     let testService
     let responseCounter = 0
@@ -91,10 +91,12 @@ describe('requestContextPlugin E2E', () => {
         const promiseRequest1 = new Promise((resolveRequest1Promise) => {
           const route = (req) => {
             const onRequestValue = req.requestContext.get('onRequest')
+            const preParsingValue = req.requestContext.get('preParsing')
             const preValidationValue = req.requestContext.get('preValidation')
             const preHandlerValue = req.requestContext.get('preHandler')
 
             expect(onRequestValue).toBe(undefined)
+            expect(preParsingValue).toBe(undefined)
             expect(preValidationValue).toEqual(expect.any(Number))
             expect(preHandlerValue).toEqual(expect.any(Number))
 
@@ -159,13 +161,15 @@ describe('requestContextPlugin E2E', () => {
   })
 
   it('does not lose request context after body parsing', () => {
-    expect.assertions(6)
+    expect.assertions(7)
     const route = (req) => {
       const onRequestValue = req.requestContext.get('onRequest')
+      const preParsingValue = req.requestContext.get('preParsing')
       const preValidationValue = req.requestContext.get('preValidation')
       const preHandlerValue = req.requestContext.get('preHandler')
 
       expect(onRequestValue).toBe('dummy')
+      expect(preParsingValue).toBe('dummy')
       expect(preValidationValue).toEqual(expect.any(Number))
       expect(preHandlerValue).toEqual(expect.any(Number))
 


### PR DESCRIPTION
Hello.

Following [this discussion](https://github.com/fastify/fastify/issues/3503), this PR aims to revert https://github.com/fastify/fastify-request-context/pull/87 :
- add back `preParsing` references from tests
- add back `preParsing` usage to the plugin code
- add back `preParsing` to the types definition


#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
