### PR TITLE
`defaultStoreValues()` is sent the `request`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ fastify.register(fastifyRequestContextPlugin, {
 This plugin accepts options `hook` and `defaultStoreValues`. 
 
 * `hook` allows you to specify to which lifecycle hook should request context initialization be bound. Note that you need to initialize it on the earliest lifecycle stage that you intend to use it in, or earlier. Default value is `onRequest`.
-* `defaultStoreValues` sets initial values for the store (that can be later overwritten during request execution if needed). This is an optional parameter.
+* `defaultStoreValues` / `defaultStoreValues(req: FastifyRequest)` sets initial values for the store (that can be later overwritten during request execution if needed). Can be set to either an object or a function that returns an object. The function will be sent the request object for the new context. This is an optional parameter.
 
 From there you can set a context in another hook, route, or method that is within scope.
 

--- a/index.js
+++ b/index.js
@@ -15,12 +15,12 @@ function fastifyRequestContext(fastify, opts, next) {
   fastify.decorateRequest('requestContext', { getter: () => requestContext })
   fastify.decorateRequest(asyncResourceSymbol, null)
   const hook = opts.hook || 'onRequest'
+  const hasDefaultStoreValuesFactory = typeof opts.defaultStoreValues === 'function'
 
   fastify.addHook(hook, (req, res, done) => {
-    const defaultStoreValues =
-      typeof opts.defaultStoreValues === 'function'
-        ? opts.defaultStoreValues(req)
-        : opts.defaultStoreValues
+    const defaultStoreValues = hasDefaultStoreValuesFactory
+      ? opts.defaultStoreValues(req)
+      : opts.defaultStoreValues
 
     als.runWith(() => {
       const asyncResource = new AsyncResource('fastify-request-context')

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function fastifyRequestContext(fastify, opts, next) {
   fastify.addHook(hook, (req, res, done) => {
     const defaultStoreValues =
       typeof opts.defaultStoreValues === 'function'
-        ? opts.defaultStoreValues()
+        ? opts.defaultStoreValues(req)
         : opts.defaultStoreValues
 
     als.runWith(() => {

--- a/test-tap/requestContextPlugin.e2e.test.js
+++ b/test-tap/requestContextPlugin.e2e.test.js
@@ -226,3 +226,24 @@ test('does not affect new request context when mutating context data using defau
       })
   })
 })
+
+test('ensure request instance is properly exposed to default values factory', (t) => {
+  t.plan(1)
+
+  const route = (req) => {
+    return Promise.resolve({ userId: req.requestContext.get('user').id })
+  }
+
+  app = initAppGetWithDefaultStoreValues(route, (req) => ({
+    user: { id: req.protocol },
+  }))
+
+  return app.listen({ port: 0, host: '127.0.0.1' }).then(() => {
+    const { address, port } = app.server.address()
+    const url = `${address}:${port}`
+
+    return request('GET', url).then((response1) => {
+      t.equal(response1.body.userId, 'http')
+    })
+  })
+})

--- a/test/requestContextPlugin.e2e.spec.js
+++ b/test/requestContextPlugin.e2e.spec.js
@@ -224,4 +224,25 @@ describe('requestContextPlugin E2E', () => {
         })
     })
   })
+
+  test('ensure request instance is properly exposed to default values factory', () => {
+    expect.assertions(1)
+
+    const route = (req) => {
+      return Promise.resolve({ userId: req.requestContext.get('user').id })
+    }
+
+    app = initAppGetWithDefaultStoreValues(route, (req) => ({
+      user: { id: req.protocol },
+    }))
+
+    return app.listen({ port: 0, host: '127.0.0.1' }).then(() => {
+      const { address, port } = app.server.address()
+      const url = `${address}:${port}`
+
+      return request('GET', url).then((response1) => {
+        expect(response1.body.userId).toBe('http')
+      })
+    })
+  })
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import { FastifyPluginCallback } from 'fastify'
+import { FastifyPluginCallback, FastifyRequest } from 'fastify'
 
 type FastifyRequestContext = FastifyPluginCallback<fastifyRequestContext.FastifyRequestContextOptions>
 
@@ -22,7 +22,7 @@ declare namespace fastifyRequestContext {
     set<K extends keyof RequestContextData>(key: K, value: RequestContextData[K]): void
   }
 
-  export type RequestContextDataFactory = () => RequestContextData
+  export type RequestContextDataFactory = (req: FastifyRequest) => RequestContextData
 
   export type Hook =
     | 'onRequest'

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -27,9 +27,18 @@ expectAssignable<RequestContextOptions>({
   })
 })
 
-
 expectAssignable<RequestContextDataFactory>(() => ({
   a: 'dummy'
+}))
+
+expectAssignable<RequestContextOptions>({
+  defaultStoreValues: req => ({
+    log: req.log.child({ childLog: true })
+  })
+})
+
+expectAssignable<RequestContextDataFactory>(req => ({
+  log: req.log.child({ childLog: true })
 }))
 
 expectType<RequestContext>(app.requestContext)


### PR DESCRIPTION
This PR fixes #156 by adding the current request instance as a parameter to the `defaultStoreValues()` factory

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and ~~`npm run benchmark`~~ (does not exist on this project)
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
