### PR TITLE
Use vanilla `AsyncLocalStorage` instead of `asynchronous-local-storage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ Next, set up the plugin:
 const { fastifyRequestContextPlugin } = require('@fastify/request-context')
 const fastify = require('fastify');
 
+fastify.register(fastifyRequestContextPlugin);
+``` 
+
+Or customize hook and default store values:
+
+```js
+const { fastifyRequestContextPlugin } = require('@fastify/request-context')
+const fastify = require('fastify');
+
 fastify.register(fastifyRequestContextPlugin, { 
   hook: 'preValidation',
   defaultStoreValues: {
@@ -36,17 +45,15 @@ fastify.register(fastifyRequestContextPlugin, {
 });
 ``` 
 
-Note that when you mutate the object got from the request context it will affect future requests.
-To prevent this behaviour you can use defaultStoreValues factory:
+Default store values can be set through a function as well:
 
 ```js
 const { fastifyRequestContextPlugin } = require('@fastify/request-context')
 const fastify = require('fastify');
 
 fastify.register(fastifyRequestContextPlugin, {
-  hook: 'preValidation',
-  defaultStoreValues: () => ({
-    user: { id: 'system' }
+  defaultStoreValues: request => ({
+    log: request.log.child({ foo: 123 })
   })
 });
 ```

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "prettier": "prettier --write \"{lib,test,test-tap}/**/*.js\" index.js index.d.ts"
   },
   "dependencies": {
-    "asynchronous-local-storage": "^1.0.2",
     "fastify-plugin": "^4.0.0"
   },
   "devDependencies": {

--- a/test-tap/requestContextPlugin.e2e.test.js
+++ b/test-tap/requestContextPlugin.e2e.test.js
@@ -247,3 +247,26 @@ test('ensure request instance is properly exposed to default values factory', (t
     })
   })
 })
+
+test('does not throw when accessing context object outside of context', (t) => {
+  t.plan(2)
+
+  const route = (req) => {
+    return Promise.resolve({ userId: req.requestContext.get('user').id })
+  }
+
+  app = initAppGetWithDefaultStoreValues(route, {
+    user: { id: 'system' },
+  })
+
+  return app.listen({ port: 0, host: '127.0.0.1' }).then(() => {
+    const { address, port } = app.server.address()
+    const url = `${address}:${port}`
+
+    t.equal(app.requestContext.get('user'), undefined)
+
+    return request('GET', url).then((response1) => {
+      t.equal(response1.body.userId, 'system')
+    })
+  })
+})

--- a/test-tap/requestContextPlugin.e2e.test.js
+++ b/test-tap/requestContextPlugin.e2e.test.js
@@ -195,6 +195,68 @@ test('correctly preserves values set in multiple phases within single POST reque
   })
 })
 
+test('does not affect new request context when mutating context data using no default values object', (t) => {
+  t.plan(2)
+
+  const route = (req) => {
+    const { action } = req.query
+    if (action === 'setvalue') {
+      req.requestContext.set('foo', 'abc')
+    }
+
+    return Promise.resolve({ userId: req.requestContext.get('foo') })
+  }
+
+  app = initAppGetWithDefaultStoreValues(route, undefined)
+
+  return app.listen({ port: 0, host: '127.0.0.1' }).then(() => {
+    const { address, port } = app.server.address()
+    const url = `${address}:${port}`
+
+    return request('GET', url)
+      .query({ action: 'setvalue' })
+      .then((response1) => {
+        t.equal(response1.body.userId, 'abc')
+
+        return request('GET', url).then((response2) => {
+          t.notOk(response2.body.userId)
+        })
+      })
+  })
+})
+
+test('does not affect new request context when mutating context data using default values object', (t) => {
+  t.plan(2)
+
+  const route = (req) => {
+    const { action } = req.query
+    if (action === 'setvalue') {
+      req.requestContext.set('foo', 'abc')
+    }
+
+    return Promise.resolve({ userId: req.requestContext.get('foo') })
+  }
+
+  app = initAppGetWithDefaultStoreValues(route, {
+    foo: 'bar',
+  })
+
+  return app.listen({ port: 0, host: '127.0.0.1' }).then(() => {
+    const { address, port } = app.server.address()
+    const url = `${address}:${port}`
+
+    return request('GET', url)
+      .query({ action: 'setvalue' })
+      .then((response1) => {
+        t.equal(response1.body.userId, 'abc')
+
+        return request('GET', url).then((response2) => {
+          t.equal(response2.body.userId, 'bar')
+        })
+      })
+  })
+})
+
 test('does not affect new request context when mutating context data using default values factory', (t) => {
   t.plan(2)
 

--- a/test/requestContextPlugin.e2e.spec.js
+++ b/test/requestContextPlugin.e2e.spec.js
@@ -245,4 +245,27 @@ describe('requestContextPlugin E2E', () => {
       })
     })
   })
+
+  test('does not throw when accessing context object outside of context', () => {
+    expect.assertions(2)
+
+    const route = (req) => {
+      return Promise.resolve({ userId: req.requestContext.get('user').id })
+    }
+
+    app = initAppGetWithDefaultStoreValues(route, {
+      user: { id: 'system' },
+    })
+
+    return app.listen({ port: 0, host: '127.0.0.1' }).then(() => {
+      const { address, port } = app.server.address()
+      const url = `${address}:${port}`
+
+      expect(app.requestContext.get('user')).toBe(undefined)
+
+      return request('GET', url).then((response1) => {
+        expect(response1.body.userId).toBe('system')
+      })
+    })
+  })
 })

--- a/test/requestContextPlugin.e2e.spec.js
+++ b/test/requestContextPlugin.e2e.spec.js
@@ -193,6 +193,68 @@ describe('requestContextPlugin E2E', () => {
     })
   })
 
+  test('does not affect new request context when mutating context data using no default values object', () => {
+    expect.assertions(2)
+
+    const route = (req) => {
+      const { action } = req.query
+      if (action === 'setvalue') {
+        req.requestContext.set('foo', 'abc')
+      }
+
+      return Promise.resolve({ userId: req.requestContext.get('foo') })
+    }
+
+    app = initAppGetWithDefaultStoreValues(route, undefined)
+
+    return app.listen({ port: 0, host: '127.0.0.1' }).then(() => {
+      const { address, port } = app.server.address()
+      const url = `${address}:${port}`
+
+      return request('GET', url)
+        .query({ action: 'setvalue' })
+        .then((response1) => {
+          expect(response1.body.userId).toEqual('abc')
+
+          return request('GET', url).then((response2) => {
+            expect(response2.body.userId).toBeUndefined()
+          })
+        })
+    })
+  })
+
+  test('does not affect new request context when mutating context data using default values object', () => {
+    expect.assertions(2)
+
+    const route = (req) => {
+      const { action } = req.query
+      if (action === 'setvalue') {
+        req.requestContext.set('foo', 'abc')
+      }
+
+      return Promise.resolve({ userId: req.requestContext.get('foo') })
+    }
+
+    app = initAppGetWithDefaultStoreValues(route, {
+      foo: 'bar',
+    })
+
+    return app.listen({ port: 0, host: '127.0.0.1' }).then(() => {
+      const { address, port } = app.server.address()
+      const url = `${address}:${port}`
+
+      return request('GET', url)
+        .query({ action: 'setvalue' })
+        .then((response1) => {
+          expect(response1.body.userId).toEqual('abc')
+
+          return request('GET', url).then((response2) => {
+            expect(response2.body.userId).toEqual('bar')
+          })
+        })
+    })
+  })
+
   it('does not affect new request context when mutating context data using default values factory', () => {
     expect.assertions(2)
 


### PR DESCRIPTION
Fixes #148 by removing `asynchronous-local-storage` in favor of built in `AsyncLocalStorage`

Requires that Node.js v14 is dropped.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] ~~documentation is changed or added~~
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
