### PR TITLE
fix: refactor requestContextPlugin.spec.js to use response headers 

### DIFF
--- a/test/requestContextPlugin.spec.js
+++ b/test/requestContextPlugin.spec.js
@@ -26,9 +26,7 @@ describe('requestContextPlugin', () => {
             function prepareReply() {
               return testService.processRequest(requestId).then(() => {
                 const storedValue = req.requestContext.get('testKey')
-                reply.status(204).send({
-                  storedValue,
-                })
+                reply.status(204).header('storedvalue', storedValue).send()
               })
             }
 
@@ -58,7 +56,7 @@ describe('requestContextPlugin', () => {
                 .query({ requestId: 1 })
                 .end()
                 .then((response) => {
-                  expect(response.json().storedValue).toBe('testValue1')
+                  expect(response.headers.storedvalue).toBe('testValue1')
                   responseCounter++
                   if (responseCounter === 2) {
                     resolveResponsePromise()
@@ -71,7 +69,7 @@ describe('requestContextPlugin', () => {
                 .query({ requestId: 2 })
                 .end()
                 .then((response) => {
-                  expect(response.json().storedValue).toBe('testValue2')
+                  expect(response.headers.storedvalue).toBe('testValue2')
                   responseCounter++
                   if (responseCounter === 2) {
                     resolveResponsePromise()
@@ -101,9 +99,7 @@ describe('requestContextPlugin', () => {
             function prepareReply() {
               return testService.processRequest(requestId).then(() => {
                 const storedValue = req.requestContext.get('testKey')
-                reply.status(204).send({
-                  storedValue,
-                })
+                reply.status(204).header('storedvalue', storedValue).send()
               })
             }
 
@@ -133,7 +129,7 @@ describe('requestContextPlugin', () => {
                 .body({ requestId: 1 })
                 .end()
                 .then((response) => {
-                  expect(response.json().storedValue).toBe('testValue1')
+                  expect(response.headers.storedvalue).toBe('testValue1')
                   responseCounter++
                   if (responseCounter === 2) {
                     resolveResponsePromise()
@@ -146,7 +142,7 @@ describe('requestContextPlugin', () => {
                 .body({ requestId: 2 })
                 .end()
                 .then((response) => {
-                  expect(response.json().storedValue).toBe('testValue2')
+                  expect(response.headers.storedvalue).toBe('testValue2')
                   responseCounter++
                   if (responseCounter === 2) {
                     resolveResponsePromise()
@@ -178,9 +174,7 @@ describe('requestContextPlugin', () => {
             function prepareReply() {
               return testService.processRequest(requestId.replace('testValue', '')).then(() => {
                 const storedValue = req.requestContext.get('testKey')
-                reply.status(204).send({
-                  storedValue,
-                })
+                reply.status(204).header('storedvalue', storedValue).send()
               })
             }
 
@@ -207,7 +201,7 @@ describe('requestContextPlugin', () => {
                 .body({ requestId: 1 })
                 .end()
                 .then((response) => {
-                  expect(response.json().storedValue).toBe('testValue1')
+                  expect(response.headers.storedvalue).toBe('testValue1')
                   responseCounter++
                   if (responseCounter === 2) {
                     resolveResponsePromise()
@@ -220,7 +214,7 @@ describe('requestContextPlugin', () => {
                 .body({ requestId: 2 })
                 .end()
                 .then((response) => {
-                  expect(response.json().storedValue).toBe('testValue2')
+                  expect(response.headers.storedvalue).toBe('testValue2')
                   responseCounter++
                   if (responseCounter === 2) {
                     resolveResponsePromise()


### PR DESCRIPTION
Fixes #175 

I replaced the json body with value in headers. I found this to be the best approach. if anyone has any better solutions, happy to implement that as well. 

#### Checklist

- [x] run `npm run test` and `npm run benchmark` (can't find script benchmark)
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
