### PR TITLE
fix: change requestContextPlugin.spec.js status code from 204 to 200

### DIFF
--- a/test/requestContextPlugin.spec.js
+++ b/test/requestContextPlugin.spec.js
@@ -26,7 +26,7 @@ describe('requestContextPlugin', () => {
             function prepareReply() {
               return testService.processRequest(requestId).then(() => {
                 const storedValue = req.requestContext.get('testKey')
-                reply.status(204).send({
+                reply.status(200).send({
                   storedValue,
                 })
               })
@@ -101,7 +101,7 @@ describe('requestContextPlugin', () => {
             function prepareReply() {
               return testService.processRequest(requestId).then(() => {
                 const storedValue = req.requestContext.get('testKey')
-                reply.status(204).send({
+                reply.status(200).send({
                   storedValue,
                 })
               })
@@ -178,7 +178,7 @@ describe('requestContextPlugin', () => {
             function prepareReply() {
               return testService.processRequest(requestId.replace('testValue', '')).then(() => {
                 const storedValue = req.requestContext.get('testKey')
-                reply.status(204).send({
+                reply.status(200).send({
                   storedValue,
                 })
               })


### PR DESCRIPTION
Fixes #175

In the current send, we're actually sending an object with a value, so probably the 200 status code is better instead of a no content code

#### Checklist

- [x] run `npm run test` 
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
