### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
     "@types/node": "^22.0.0",
-    "eslint": "^9.6.0",
+    "eslint": "^9.17.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "fastify": "^5.0.0",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.