### PR TITLE
chore(readme): update references to deprecated name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,19 +25,19 @@ npm i @fastify/request-context
 Next, set up the plugin:
 
 ```js
-const { fastifyRequestContextPlugin } = require('@fastify/request-context')
+const { fastifyRequestContext } = require('@fastify/request-context')
 const fastify = require('fastify');
 
-fastify.register(fastifyRequestContextPlugin);
+fastify.register(fastifyRequestContext);
 ```
 
 Or customize hook and default store values:
 
 ```js
-const { fastifyRequestContextPlugin } = require('@fastify/request-context')
+const { fastifyRequestContext } = require('@fastify/request-context')
 const fastify = require('fastify');
 
-fastify.register(fastifyRequestContextPlugin, {
+fastify.register(fastifyRequestContext, {
   hook: 'preValidation',
   defaultStoreValues: {
     user: { id: 'system' }
@@ -48,10 +48,10 @@ fastify.register(fastifyRequestContextPlugin, {
 Default store values can be set through a function as well:
 
 ```js
-const { fastifyRequestContextPlugin } = require('@fastify/request-context')
+const { fastifyRequestContext } = require('@fastify/request-context')
 const fastify = require('fastify');
 
-fastify.register(fastifyRequestContextPlugin, {
+fastify.register(fastifyRequestContext, {
   defaultStoreValues: request => ({
     log: request.log.child({ foo: 123 })
   })
@@ -71,11 +71,11 @@ Request context (with methods `get` and `set`) is exposed by library itself, but
 For instance:
 
 ```js
-const { fastifyRequestContextPlugin, requestContext } = require('@fastify/request-context')
+const { fastifyRequestContext, requestContext } = require('@fastify/request-context')
 const fastify = require('fastify');
 
 const app = fastify({ logger: true })
-app.register(fastifyRequestContextPlugin, {
+app.register(fastifyRequestContext, {
   defaultStoreValues: {
     user: { id: 'system' }
   },

--- a/test/internal/appInitializer.js
+++ b/test/internal/appInitializer.js
@@ -1,11 +1,11 @@
 'use strict'
 
 const fastify = require('fastify')
-const { fastifyRequestContextPlugin } = require('../..')
+const { fastifyRequestContext } = require('../..')
 
 function initAppGet(endpoint) {
   const app = fastify({ logger: true })
-  app.register(fastifyRequestContextPlugin)
+  app.register(fastifyRequestContext)
 
   app.get('/', endpoint)
   return app
@@ -13,7 +13,7 @@ function initAppGet(endpoint) {
 
 function initAppPost(endpoint) {
   const app = fastify({ logger: true })
-  app.register(fastifyRequestContextPlugin)
+  app.register(fastifyRequestContext)
 
   app.post('/', endpoint)
 
@@ -22,7 +22,7 @@ function initAppPost(endpoint) {
 
 function initAppPostWithPrevalidation(endpoint) {
   const app = fastify({ logger: true })
-  app.register(fastifyRequestContextPlugin, { hook: 'preValidation' })
+  app.register(fastifyRequestContext, { hook: 'preValidation' })
 
   const preValidationFn = (req, reply, done) => {
     const requestId = Number.parseInt(req.body.requestId)
@@ -42,7 +42,7 @@ function initAppPostWithPrevalidation(endpoint) {
 
 function initAppPostWithAllPlugins(endpoint, requestHook) {
   const app = fastify({ logger: true })
-  app.register(fastifyRequestContextPlugin, { hook: requestHook })
+  app.register(fastifyRequestContext, { hook: requestHook })
 
   app.addHook('onRequest', (req, reply, done) => {
     req.requestContext.set('onRequest', 'dummy')
@@ -87,7 +87,7 @@ function initAppPostWithAllPlugins(endpoint, requestHook) {
 
 function initAppGetWithDefaultStoreValues(endpoint, defaultStoreValues) {
   const app = fastify({ logger: true })
-  app.register(fastifyRequestContextPlugin, {
+  app.register(fastifyRequestContext, {
     defaultStoreValues,
   })
 


### PR DESCRIPTION
Currently readme and tests both reference `fastifyRequestContextPlugin`,
which index file marks as deprecated reference to `fastifyRequestContext`.

So this updates readme and test file to not use deprecated reference.
