### PR TITLE
Export asyncLocalStorage to allow running it in another place

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ module.exports = fp(fastifyRequestContext, {
 })
 module.exports.default = fastifyRequestContext
 module.exports.fastifyRequestContext = fastifyRequestContext
-
+module.exports.asyncLocalStorage = asyncLocalStorage
 module.exports.requestContext = requestContext
 
 // Deprecated


### PR DESCRIPTION
Exporting it should allow developers to write tests where you can set the context artificially.

```js
import { asyncLocalStorage } from '@fastify/request-context';

it('should set request context', () => {
  asyncLocalStorage.run({}, async () => {
    requestContext.set('userId', 'some-fake-user-id');
    someCodeThatUsesRequestContext(); // requestContext.get('userId') will work
  })
})
```

Closes #211 