### PR TITLE
Add docs and types for exposing asyncLocalStorage instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,20 @@ const bar = requestContext.get('bar')
 
 If you have `"strictNullChecks": true` (or have `"strict": true`, which sets `"strictNullChecks": true`) in your TypeScript configuration, you will notice that the type of the returned value can still be `undefined` even though the `RequestContextData` interface has a specific type. For a discussion about how to work around this and the pros/cons of doing so, please read [this issue (#93)](https://github.com/fastify/fastify-request-context/issues/93).
 
+## Usage outside of a request
+
+If functions depend on requestContext but are not called in a request, i.e. in tests or workers, they can be wrapped in the asyncLocalStorage instance of requestContext:
+
+```
+import { asyncLocalStorage } from '@fastify/request-context';
+
+it('should set request context', () => {
+  asyncLocalStorage.run({}, async () => {
+    requestContext.set('userId', 'some-fake-user-id');
+    someCodeThatUsesRequestContext(); // requestContext.get('userId') will work
+  })
+})
+```
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ module.exports = fp(fastifyRequestContext, {
 })
 module.exports.default = fastifyRequestContext
 module.exports.fastifyRequestContext = fastifyRequestContext
-
+module.exports.asyncLocalStorage = asyncLocalStorage
 module.exports.requestContext = requestContext
 
 // Deprecated

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -53,7 +53,7 @@ declare namespace fastifyRequestContext {
   }
 
   export const requestContext: RequestContext
-  export const asyncLocalStorage: AsyncLocalStorage<any>
+  export const asyncLocalStorage: AsyncLocalStorage<RequestContext>
   /**
    * @deprecated Use FastifyRequestContextOptions instead
    */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import { AsyncResource } from 'node:async_hooks'
+import { AsyncLocalStorage, AsyncResource } from 'node:async_hooks'
 import { FastifyPluginCallback, FastifyRequest } from 'fastify'
 
 type FastifyRequestContext =
@@ -53,7 +53,7 @@ declare namespace fastifyRequestContext {
   }
 
   export const requestContext: RequestContext
-
+  export const asyncLocalStorage: AsyncLocalStorage
   /**
    * @deprecated Use FastifyRequestContextOptions instead
    */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -53,7 +53,7 @@ declare namespace fastifyRequestContext {
   }
 
   export const requestContext: RequestContext
-  export const asyncLocalStorage: AsyncLocalStorage
+  export const asyncLocalStorage: AsyncLocalStorage<any>
   /**
    * @deprecated Use FastifyRequestContextOptions instead
    */

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,5 +1,6 @@
 import {
   requestContext,
+  asyncLocalStorage,
   fastifyRequestContext,
   FastifyRequestContextOptions,
   RequestContext,
@@ -7,6 +8,7 @@ import {
 } from '..'
 import { expectAssignable, expectType, expectError } from 'tsd'
 import { FastifyBaseLogger, FastifyInstance, RouteHandlerMethod } from 'fastify'
+import { AsyncLocalStorage } from 'node:async_hooks'
 
 const fastify = require('fastify')
 
@@ -61,6 +63,7 @@ expectError<RequestContextDataFactory>(() => ({ log: 'dummy' }))
 
 expectType<RequestContext>(app.requestContext)
 expectType<RequestContext>(requestContext)
+expectType<AsyncLocalStorage<any>>(asyncLocalStorage)
 
 const getHandler: RouteHandlerMethod = function (request, _reply) {
   expectType<RequestContext>(request.requestContext)

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -63,7 +63,7 @@ expectError<RequestContextDataFactory>(() => ({ log: 'dummy' }))
 
 expectType<RequestContext>(app.requestContext)
 expectType<RequestContext>(requestContext)
-expectType<AsyncLocalStorage<any>>(asyncLocalStorage)
+expectType<AsyncLocalStorage<RequestContext>>(asyncLocalStorage)
 
 const getHandler: RouteHandlerMethod = function (request, _reply) {
   expectType<RequestContext>(request.requestContext)


### PR DESCRIPTION
The PR includes the commits of:
https://github.com/fastify/fastify-request-context/pull/213
Closes https://github.com/fastify/fastify-request-context/pull/213

It adds documentation and types.



Hope it is alright that I bypass the other PR, since it is open since February. I am also in favor of exposing the asyncLocalStorage type, since it is useful to use in bullmq workers, too.

