### PR TITLE
Fix: Correct AsyncLocalStorage type parameter to match actual store

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -54,7 +54,7 @@ declare namespace fastifyRequestContext {
   }
 
   export const requestContext: RequestContext
-  export const asyncLocalStorage: AsyncLocalStorage<RequestContext>
+  export const asyncLocalStorage: AsyncLocalStorage<RequestContextData>
   /**
    * @deprecated Use FastifyRequestContextOptions instead
    */

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -5,6 +5,7 @@ import {
   FastifyRequestContextOptions,
   RequestContext,
   RequestContextDataFactory,
+  RequestContextData,
 } from '..'
 import { expectAssignable, expectType, expectError } from 'tsd'
 import { FastifyBaseLogger, FastifyInstance, RouteHandlerMethod } from 'fastify'
@@ -63,7 +64,7 @@ expectError<RequestContextDataFactory>(() => ({ log: 'dummy' }))
 
 expectType<RequestContext>(app.requestContext)
 expectType<RequestContext>(requestContext)
-expectType<AsyncLocalStorage<RequestContext>>(asyncLocalStorage)
+expectType<AsyncLocalStorage<RequestContextData>>(asyncLocalStorage)
 
 const getHandler: RouteHandlerMethod = function (request, _reply) {
   expectType<RequestContext>(request.requestContext)


### PR DESCRIPTION
Fix: Correct AsyncLocalStorage type parameter to match actual store (RequestContextData)

The AsyncLocalStorage was incorrectly typed as RequestContext, but in reality it stores RequestContextData, which is directly accessed via key-value operations (e.g. store[key]).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ + ] run `npm run test` and `npm run benchmark`
- [ - ] tests and/or benchmarks are included
- [ - ] documentation is changed or added
- [ + ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
