### PR TITLE
feat: add function name for hooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function fastifyRequestContext(fastify, opts, next) {
   const hook = opts.hook || 'onRequest'
   const hasDefaultStoreValuesFactory = typeof opts.defaultStoreValues === 'function'
 
-  fastify.addHook(hook, (req, _res, done) => {
+  fastify.addHook(hook, function requestContextHook(req, _res, done) {
     const defaultStoreValues = hasDefaultStoreValuesFactory
       ? opts.defaultStoreValues(req)
       : opts.defaultStoreValues
@@ -51,7 +51,7 @@ function fastifyRequestContext(fastify, opts, next) {
   // in a different async context, as req/res may emit events in a different context.
   // Related to https://github.com/nodejs/node/issues/34430 and https://github.com/nodejs/node/issues/33723
   if (hook === 'onRequest' || hook === 'preParsing') {
-    fastify.addHook('preValidation', (req, _res, done) => {
+    fastify.addHook('preValidation', function requestContextPreValidationHook(req, _res, done) {
       const asyncResource = req[asyncResourceSymbol]
       asyncResource.runInAsyncScope(done, req.raw)
     })

--- a/test/requestContextPlugin.spec.js
+++ b/test/requestContextPlugin.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { default: fastify } = require('fastify')
 const {
   initAppPost,
   initAppPostWithPrevalidation,

--- a/test/requestContextPlugin.spec.js
+++ b/test/requestContextPlugin.spec.js
@@ -8,7 +8,6 @@ const {
 } = require('./internal/appInitializer')
 const { TestService } = require('./internal/testService')
 const { describe, afterEach, test } = require('node:test')
-const { fastifyRequestContext } = require('..')
 
 describe('requestContextPlugin', () => {
   let app

--- a/test/requestContextPlugin.spec.js
+++ b/test/requestContextPlugin.spec.js
@@ -354,23 +354,4 @@ describe('requestContextPlugin', () => {
       return promiseRequest2
     })
   })
-
-  test('hook functions are named', async (t) => {
-    const app = fastify({ logger: true })
-
-    const calls = []
-    app.addHook = function (...args) {
-      calls.push(args)
-      return this
-    }
-
-    await app.register(fastifyRequestContext)
-
-    t.assert.equal(calls.length, 2)
-    t.assert.equal(calls[0][0], 'onRequest')
-    t.assert.equal(calls[0][1].name, 'requestContextHook') // assert hook function is named
-
-    t.assert.equal(calls[1][0], 'preValidation')
-    t.assert.equal(calls[1][1].name, 'requestContextPreValidationHook')
-  })
 })

--- a/test/requestContextPlugin.spec.js
+++ b/test/requestContextPlugin.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { default: fastify } = require('fastify')
 const {
   initAppPost,
   initAppPostWithPrevalidation,
@@ -8,6 +9,7 @@ const {
 } = require('./internal/appInitializer')
 const { TestService } = require('./internal/testService')
 const { describe, afterEach, test } = require('node:test')
+const { fastifyRequestContext } = require('..')
 
 describe('requestContextPlugin', () => {
   let app
@@ -351,5 +353,26 @@ describe('requestContextPlugin', () => {
 
       return promiseRequest2
     })
+  })
+
+  test('hook functions are named', async (t) => {
+    const app = fastify({ logger: true })
+
+    const calls = []
+    app.addHook = function (...args) {
+      calls.push(args)
+      return this
+    }
+
+    await app.register(fastifyRequestContext)
+
+    t.assert.equal(calls.length, 2)
+    t.assert.equal(calls[0][0], 'onRequest')
+    t.assert.equal(calls[0][1].name, 'requestContextHook') // assert hook function is named
+
+    t.assert.equal(calls[1][0], 'preValidation')
+    t.assert.equal(calls[1][1].name, 'requestContextPreValidationHook')
+
+    console.log(calls)
   })
 })

--- a/test/requestContextPlugin.spec.js
+++ b/test/requestContextPlugin.spec.js
@@ -372,7 +372,5 @@ describe('requestContextPlugin', () => {
 
     t.assert.equal(calls[1][0], 'preValidation')
     t.assert.equal(calls[1][1].name, 'requestContextPreValidationHook')
-
-    console.log(calls)
   })
 })


### PR DESCRIPTION
@fastify/otel uses hook function name as span name. Providing correct span name eliminates anonymous spans in traces.


Old spans:

<img width="824" height="355" alt="Screenshot 2025-08-11 at 8 50 47 PM" src="https://github.com/user-attachments/assets/2367ab6e-0a4c-4f59-a1e8-d33386ed83e8" />

New spans:

<img width="847" height="350" alt="Screenshot 2025-08-11 at 8 50 42 PM" src="https://github.com/user-attachments/assets/357681a1-301e-4d5f-9955-fd5700f34699" />


#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
