### PR TITLE
chore: removed types and exports deprecated

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,6 +68,3 @@ module.exports.default = fastifyRequestContext
 module.exports.fastifyRequestContext = fastifyRequestContext
 module.exports.asyncLocalStorage = asyncLocalStorage
 module.exports.requestContext = requestContext
-
-// Deprecated
-module.exports.fastifyRequestContextPlugin = fastifyRequestContext

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -55,16 +55,6 @@ declare namespace fastifyRequestContext {
 
   export const requestContext: RequestContext
   export const asyncLocalStorage: AsyncLocalStorage<RequestContext>
-  /**
-   * @deprecated Use FastifyRequestContextOptions instead
-   */
-  export type RequestContextOptions = FastifyRequestContextOptions
-
-  /**
-   * @deprecated Use fastifyRequestContext instead
-   */
-  export const fastifyRequestContextPlugin: FastifyRequestContext
-
   export const fastifyRequestContext: FastifyRequestContext
   export { fastifyRequestContext as default }
 }


### PR DESCRIPTION
Proposals:

- Remove `module.exports.fastifyRequestContextPlugin` from index.js
- Remove `RequestContextOptions` type alias from types/index.d.ts
- Remove `fastifyRequestContextPlugin` const from types/index.d.ts

Note:

- Release a major version of the plugin after this pull request has been merged
- PR reference:
   - https://github.com/fastify/fastify-swagger-ui/pull/274