### PR TITLE
chore: use https package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "superagent": "^10.0.0",
     "tstyche": "^7.0.0"
   },
-  "homepage": "http://github.com/fastify/fastify-request-context",
+  "homepage": "https://github.com/fastify/fastify-request-context",
   "funding": [
     {
       "type": "github",
@@ -44,7 +44,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/fastify/fastify-request-context.git"
+    "url": "git+https://github.com/fastify/fastify-request-context.git"
   },
   "bugs": {
     "url": "https://github.com/fastify/fastify-request-context/issues"


### PR DESCRIPTION
## Summary

- Update `package.json` repository metadata from `git://` to `git+https://`.
- Update the homepage URL from `http://` to `https://`.

## Validation

- Checked the current npm metadata for `@fastify/request-context@7.0.0`.
- Parsed `package.json` and asserted the updated repository and homepage values.
- `git diff --check`
- `git ls-remote https://github.com/fastify/fastify-request-context.git HEAD`
