### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,6 @@ it('should set request context', () => {
 Licensed under [MIT](./LICENSE).
 
 [npm-image]: https://img.shields.io/npm/v/@fastify/request-context.svg
-[npm-url]: https://npmjs.com/package/@fastify/request-context
+[npm-url]: https://www.npmjs.com/package/@fastify/request-context
 [downloads-image]: https://img.shields.io/npm/dm/fastify-request-context.svg
-[downloads-url]: https://npmjs.org/package/@fastify/request-context
+[downloads-url]: https://www.npmjs.com/package/@fastify/request-context


### PR DESCRIPTION
Fixes 404s, 3xx redirections, and missing fragments in the documentation. Part of general link cleanup being tracked in https://github.com/fastify/accept-negotiator/pull/71